### PR TITLE
Fixes to ejabberd_hooks

### DIFF
--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -279,7 +279,7 @@ handle_call({add, Hook, Host, Node, Module, Function, Seq, CallType}, _From, Sta
     {reply, Reply, State};
 
 handle_call({delete, Hook, Host, Module, Function, Seq}, _From, State) ->
-    Reply = handle_delete(Hook, Host, Seq, undefined, Module, Function),
+    Reply = handle_delete(Hook, Host, Seq, node(), Module, Function),
     {reply, Reply, State};
 handle_call({delete, Hook, Host, Node, Module, Function, Seq}, _From, State) ->
     Reply = handle_delete(Hook, Host, Seq, Node, Module, Function),
@@ -396,7 +396,7 @@ handle_delete(Hook, Host, Seq, Node, Module, Function) ->
         [{_, Ls}] ->
             Filter = fun(HookTuple) ->
                              case HookTuple of
-                                 {Seq, Module, Function, _CallType} -> false;
+                                 {Seq, Module, Function, _CallType} -> Node /= node();
                                  {Seq, Node, Module, Function, _CallType} -> false;
                                  _ -> true
                              end

--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -301,7 +301,8 @@ handle_call({delete_all}, _From, State) ->
     {reply, Reply, State};
 
 handle_call({get_hooks_with_handlers}, _From, State) ->
-    Hooks = ets:foldl(fun({{Hook, _Host}, _}, Acc) -> [Hook|Acc] end, [], hooks),
+    Hooks = ets:foldl(fun({_, []}, Acc)            -> Acc;
+                         ({{Hook, _Host}, _}, Acc) -> [Hook|Acc] end, [], hooks),
     %% This is in case a hook is both global / local, but I do not think this can be the case:
     Reply = lists:usort(Hooks),
     {reply, Reply, State};

--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -581,31 +581,11 @@ do_format_args(Hook, args, Args) ->
 do_format_args(Hook, record, Args) ->
     case Args of
         R when is_tuple(R) -> [R];
-        [] -> []; %% Do not convert empty parameter list to "empty record tuple"
         A when is_list(A)  -> [list_to_tuple([Hook | Args])]
     end.
 
 format_args(Hook, CallType, Val, Args) ->
-    case is_core_hook(Hook) of
-        %% Do not change "custom" hooks type (Can be not yet migrated hooks)
-        false -> [Val|Args];
-        true  -> do_format_args(Hook, CallType, Val, Args)
-    end.
-
-do_format_args(Hook, args, Val, Args) ->
-    case Args of
-        A when is_list(A)  -> [Val | Args];
-        R when is_tuple(R) ->
-            case tuple_to_list(R) of
-                [Hook|RecordArgs] -> [Val|RecordArgs];
-                _ -> [Val | Args ]
-            end
-    end;
-do_format_args(Hook, record, Val, Args) ->
-    case Args of
-        R when is_tuple(R) -> [Val, R];
-        A when is_list(A)  -> [Val, list_to_tuple([Hook | Args])]
-    end.
+    [Val | format_args(Hook, CallType, Args)].
 
 
 %% Perform hooks calls (actually)

--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -466,43 +466,43 @@ run1([], _Hook, _Args) ->
 run1([{_Seq, Node, Module, Function, CallType} | Ls], Hook, Args) ->
     case remote_apply(Node, Module, Function, format_args(Hook, CallType, Args)) of
 	timeout ->
-            io:format("Timeout on RPC to ~p~nrunning hook: ~p",
-		       [Node, {Hook, Args}]),
+            %% io:format("Timeout on RPC to ~p~nrunning hook: ~p",
+            %% 		       [Node, {Hook, Args}]),
 	    ?ERROR_MSG("Timeout on RPC to ~p~nrunning hook: ~p",
 		       [Node, {Hook, Args}]),
 	    run1(Ls, Hook, Args);
 	{badrpc, Reason} ->
-            io:format("Bad RPC error to ~p: ~p~nrunning hook: ~p",
-		       [Node, Reason, {Hook, Args}]),
+            %% io:format("Bad RPC error to ~p: ~p~nrunning hook: ~p",
+            %% 		       [Node, Reason, {Hook, Args}]),
 	    ?ERROR_MSG("Bad RPC error to ~p: ~p~nrunning hook: ~p",
 		       [Node, Reason, {Hook, Args}]),
 	    run1(Ls, Hook, Args);
 	stop ->
-            io:format("~nThe process ~p in node ~p ran a hook in node ~p.~n"
-		      "Stop.", [self(), node(), Node]), % debug code
+            %% io:format("~nThe process ~p in node ~p ran a hook in node ~p.~n"
+            %% 		      "Stop.", [self(), node(), Node]), % debug code
 	    ?INFO_MSG("~nThe process ~p in node ~p ran a hook in node ~p.~n"
 		      "Stop.", [self(), node(), Node]), % debug code
 	    ok;
 	Res ->
-            io:format("~nThe process ~p in node ~p ran a hook in node ~p.~n"
-		      "The response is: ~n~p", [self(), node(), Node, Res]), % debug code
+            %% io:format("~nThe process ~p in node ~p ran a hook in node ~p.~n"
+            %% 		      "The response is: ~n~p", [self(), node(), Node, Res]), % debug code
 	    ?INFO_MSG("~nThe process ~p in node ~p ran a hook in node ~p.~n"
 		      "The response is: ~n~p", [self(), node(), Node, Res]), % debug code
 	    run1(Ls, Hook, Args)
     end;
 run1([{_Seq, Module, Function, CallType} | Ls], Hook, Args) ->
-    io:format("MREMOND1\n",[]),
+    %% io:format("MREMOND1\n",[]),
     Res = safe_apply(Module, Function, format_args(Hook, CallType, Args)),
     case Res of
 	{'EXIT', Reason} ->
-            io:format("~p~nrunning hook: ~p", [Reason, {Hook, Args}]),
+            %% io:format("~p~nrunning hook: ~p", [Reason, {Hook, Args}]),
 	    ?ERROR_MSG("~p~nrunning hook: ~p", [Reason, {Hook, Args}]),
 	    run1(Ls, Hook, Args);
 	stop ->
-            io:format("stop", []),
+            %% io:format("stop", []),
 	    ok;
 	_ ->
-            io:format("run 1 loop", []),
+            %% io:format("run 1 loop", []),
 	    run1(Ls, Hook, Args)
     end.
 

--- a/src/ejabberd_hooks.erl
+++ b/src/ejabberd_hooks.erl
@@ -103,7 +103,7 @@ add_handler(Hook, Module, Function, Seq) ->
 add_handler(Hook, Host, Module, Function, Seq) ->
     add_handler(Hook, Host, Module, Function, Seq, record).
 
-add_handler(Hook, Host, Module, Function, Seq, CallType) -> 
+add_handler(Hook, Host, Module, Function, Seq, CallType) ->
     gen_server:call(ejabberd_hooks, {add, Hook, Host, Module, Function, Seq, CallType}).
 
 -spec add(atom(), fun(), number()) -> ok.
@@ -186,7 +186,7 @@ delete_dist(Hook, Node, Module, Function, Seq) ->
 delete_dist(Hook, Host, Node, Module, Function, Seq) ->
     gen_server:call(ejabberd_hooks, {delete, Hook, Host, Node, Module, Function, Seq}).
 
--spec delete_all_hooks() -> true. 
+-spec delete_all_hooks() -> true.
 
 %% @doc Primarily for testing / instrumentation
 delete_all_hooks() ->
@@ -199,7 +199,7 @@ get_handlers(Hookname) ->
     get_handlers(Hookname, global).
 
 -spec get_handlers(atom(), binary() | global) -> [local_hook() | distributed_hook()].
-%% @doc Returns currently set handlers for hook name 
+%% @doc Returns currently set handlers for hook name
 get_handlers(Hookname, Host) ->
     gen_server:call(ejabberd_hooks, {get_handlers, Hookname, Host}).
 
@@ -287,7 +287,7 @@ handle_call({delete, Hook, Host, Node, Module, Function, Seq}, _From, State) ->
 
 handle_call({remove_module_handlers, Hook, Host, Module}, _From, State) ->
     Reply = remove_module_handler(Hook, Host, Module),
-    {reply, Reply, State};    
+    {reply, Reply, State};
 
 handle_call({get_handlers, Hook, Host}, _From, State) ->
     Reply = case ets:lookup(hooks, {Hook, Host}) of
@@ -368,7 +368,7 @@ handle_add(HookName, Host, HookTuple) ->
                     end
             end
     end.
-    
+
 -spec do_handle_add(atom(), atom(), local_hook() | distributed_hook()) -> ok.
 %% in-memory storage operation: Handle adding hook in ETS table
 do_handle_add(Hook, Host, El) ->
@@ -400,12 +400,12 @@ handle_delete(Hook, Host, Seq, Node, Module, Function) ->
                                  _ -> true
                              end
                      end,
-            NewLs = lists:filter(Filter, Ls), 
+            NewLs = lists:filter(Filter, Ls),
             ets:insert(hooks, {{Hook, Host}, NewLs}),
             ok;
         [] ->
             ok
-    end. 
+    end.
 
 %% Drop all handlers for given module
 remove_module_handler(Hook, Host, Module) ->
@@ -418,11 +418,11 @@ remove_module_handler(Hook, Host, Module) ->
                                  _ -> true
                              end
                      end,
-            NewLs = lists:filter(Filter, Ls), 
+            NewLs = lists:filter(Filter, Ls),
             ets:insert(hooks, {{Hook, Host}, NewLs}),
             ok;
         [] -> ok
-    end. 
+    end.
 
 %%----------------------------------------------------------------------
 %% Func: handle_cast/2
@@ -567,7 +567,7 @@ format_args(Hook, CallType, Args) ->
         false -> Args;
         true  -> do_format_args(Hook, CallType, Args)
     end.
-    
+
 do_format_args(Hook, args, Args) ->
     case Args of
         A when is_list(A)  -> Args;

--- a/test/ejabberd_hooks_eqc.exs
+++ b/test/ejabberd_hooks_eqc.exs
@@ -8,9 +8,6 @@ require Record
 
 # -- Issues -----------------------------------------------------------------
 
-# - get_hooks_with_handlers returns hooks that have had handlers at some point,
-#   not just hooks that currently have handlers.
-
 # - The arity check for core_hooks doesn't work if the same handler is defined
 #   for multiple arities.
 
@@ -131,9 +128,7 @@ defp compare_handler(h1, h2),        do: h1 == Map.delete(h2, :node)
 
 # -- State ------------------------------------------------------------------
 
-# hooks_with_past_handlers are used to model the buggy behaviour of
-# get_hooks_with_handlers (see below).
-def initial_state, do: %{hooks: %{}, hooks_with_past_handlers: %{}}
+def initial_state, do: %{hooks: %{}}
 
 def get_handlers(state, name) do
   case Map.fetch(state.hooks, name) do
@@ -172,8 +167,7 @@ def add_handler_state(state, name, h, seq) do
   # usort handlers based on handler_key()
   new_handlers = :lists.usort(fn(h1, h2) -> handler_key(name, h1) <= handler_key(name, h2) end,
                               [handler|get_handlers(state, name)])
-  %{state | hooks: Map.put(state.hooks, name, new_handlers),
-            hooks_with_past_handlers: Map.put(state.hooks_with_past_handlers, name, true) }
+  %{state | hooks: Map.put(state.hooks, name, new_handlers)}
 end
 
 def filter_handlers(state, name, pred) do
@@ -472,9 +466,7 @@ def get_hooks_with_handlers_args(_state), do: []
 
 def get_hooks_with_handlers, do: :ejabberd_hooks.get_hooks_with_handlers
 
-# BUG: get_hooks_with_handlers returns hooks that have had handlers at some
-#      point. They don't necessarily have any handlers at the moment.
-def get_hooks_with_handlers_return(state, []), do: Map.keys state.hooks_with_past_handlers
+def get_hooks_with_handlers_return(state, []), do: Map.keys state.hooks
 
 # -- Common -----------------------------------------------------------------
 

--- a/test/ejabberd_hooks_eqc.exs
+++ b/test/ejabberd_hooks_eqc.exs
@@ -245,21 +245,22 @@ end
 
 def add_dist_handler_args(state) do
   [gen_hook_name(state, :any), gen_host, gen_node,
-   gen_module, gen_fun_name, gen_sequence_number]
+   fault(gen_faulty_handler, {gen_module, gen_fun_name}),
+   gen_sequence_number]
 end
 
 def add_dist_handler_pre(_state, _args), do: true
 
-def add_dist_handler(name, :no_host, node, mod, fun, seq) do
+def add_dist_handler(name, :no_host, node, {mod, fun}, seq) do
   :ejabberd_hooks.add_dist_handler(name, mk_node(node), mod, fun, seq)
 end
-def add_dist_handler(name, host, node, mod, fun, seq) do
+def add_dist_handler(name, host, node, {mod, fun}, seq) do
   :ejabberd_hooks.add_dist_handler(name, host, mk_node(node), mod, fun, seq)
 end
 
-def add_dist_handler_callouts(_state, [name, host, node, mod, fun, seq]) do
-  case check_fun(name, {mod, fun}) do
-    :ok -> call do_add_handler(name, %{host: mk_host(host), node: node, fun: {mod, fun}}, seq)
+def add_dist_handler_callouts(_state, [name, host, node, fun, seq]) do
+  case check_fun(name, fun) do
+    :ok -> call do_add_handler(name, %{host: mk_host(host), node: node, fun: fun}, seq)
     err -> {:return, err}
   end
 end

--- a/test/ejabberd_hooks_eqc.exs
+++ b/test/ejabberd_hooks_eqc.exs
@@ -8,9 +8,6 @@ require Record
 
 # -- Issues -----------------------------------------------------------------
 
-# - The arity check for core_hooks doesn't work if the same handler is defined
-#   for multiple arities.
-
 # - Sorting handlers with the same sequence number on the fun value leads to
 #   somewhat unpredictable behaviour.
 
@@ -218,9 +215,6 @@ def add_handler_args(state) do
    fault(gen_faulty_handler, gen_handler), gen_sequence_number]
 end
 
-## BUG: don't add :funX to core hooks since they don't work with multiple arity
-##      functions
-def add_handler_pre(_state, [name, _, {_, :funX}, _]), do: nil == core_hooks()[name]
 def add_handler_pre(_state, _args), do: true
 
 def add_handler(name, :no_host, {:fn, arity, id}, seq) do
@@ -254,9 +248,6 @@ def add_dist_handler_args(state) do
    gen_module, gen_fun_name, gen_sequence_number]
 end
 
-## BUG: don't add :funX to core hooks since they don't work with multiple arity
-##      functions
-def add_dist_handler_pre(_state, [name, _, _, _, :funX, _]), do: nil == core_hooks()[name]
 def add_dist_handler_pre(_state, _args), do: true
 
 def add_dist_handler(name, :no_host, node, mod, fun, seq) do


### PR DESCRIPTION
Contains the following fixes and corresponding updates to the QuickCheck model:
* `get_hooks_with_handlers` no longer returns hooks whose handlers have been removed
* `run` and `run_fold` now behave the same on empty argument lists: both call the handler with an empty record value `{hook_name}`
* `delete_dist` no longer removes local handler along with the remote handler
* adding a handler for a core hook no longer fails if the handler is defined with multiple arities (as long as one of them is the correct arity)
